### PR TITLE
Add new `Ros2Supervisor` tutorial

### DIFF
--- a/source/The-ROS2-Project/Governance.rst
+++ b/source/The-ROS2-Project/Governance.rst
@@ -293,7 +293,7 @@ Real-time
 Security
 ^^^^^^^^
 
-* Lead(s): Jeremie Deray
+* Lead(s): Florencia Cabral
 * Resources:
 
  * `ROS 2 Security Working Group Community <https://github.com/ros-security/community>`__

--- a/source/Tutorials/Advanced/FastDDS-Configuration.rst
+++ b/source/Tutorials/Advanced/FastDDS-Configuration.rst
@@ -43,15 +43,15 @@ Mixing synchronous and asynchronous publications in the same node
 
 In this first example, a node with two publishers, one of them with synchronous publication mode and the other one with asynchronous publication mode, will be created.
 
-``rmw_fastrtps`` uses asynchronous publication mode by default.
-When the publisher invokes the write operation, the data is copied into a queue,
-a background thread (asynchronous thread) is notified about the addition to the queue, and control of the thread is returned to the user before the data is actually sent.
-The background thread is in charge of consuming the queue and sending the data to every matched reader.
+``rmw_fastrtps`` uses synchronous publication mode by default.
 
-On the other hand, with synchronous publication mode the data is sent directly within the context of the user thread.
+With synchronous publication mode the data is sent directly within the context of the user thread.
 This entails that any blocking call occurring during the write operation would block the user thread, thus preventing the application from continuing its operation.
 However, this mode typically yields higher throughput rates at lower latencies, since there is no notification nor context switching between threads.
 
+On the other hand, with asynchronous publication mode, each time the publisher invokes the write operation, the data is copied into a queue,
+a background thread (asynchronous thread) is notified about the addition to the queue, and control of the thread is returned to the user before the data is actually sent.
+The background thread is in charge of consuming the queue and sending the data to every matched reader.
 
 Create the node with the publishers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
@@ -31,7 +31,7 @@ The ``Ros2Supervisor``
 
 The ``Ros2Supervisor`` is made of two main parts:
 
-* A Webots Robot node added to the simulation world. Its Supervisor field is set to TRUE.
+* A Webots Robot node added to the simulation world. Its ``supervisor`` field is set to TRUE.
 * A ROS 2 node that connects to the Webots Robot as an extern controller (in a similar way to your own robot plugin).
 
 The ROS 2 node acts as a controller that calls Supervisor API functions to control or interact with the simulation world.

--- a/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
@@ -140,4 +140,4 @@ Summary
 -------
 
 In this tutorial, you learned how to enable the ``Ros2Supervisor`` and how to extend the interface with the Webots simulation.
-The node creates multiple services and topics to interact and modify the simulation.
+The node creates multiple services and topics to interact with and modify the simulation.

--- a/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
@@ -78,7 +78,7 @@ More information about the ``/clock`` topic can be found in the `ROS wiki <http:
 Import a Webots node
 --------------------
 
-The ``Ros2Supervisor`` node also allows to spawn Webots nodes from strings through a service.
+The ``Ros2Supervisor`` node also allows you to spawn Webots nodes from strings through a service.
 
 The service is named ``/Ros2Supervisor/spawn_node_from_string`` and is of type ``webots_ros2_msgs/srv/SpawnNodeFromString``.
 The ``SpawnNodeFromString`` type expects a ``data`` string as input and returns a ``success`` boolean.

--- a/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Simulation-Supervisor.rst
@@ -1,0 +1,143 @@
+The Ros2Supervisor Node
+=======================
+
+**Goal:** Extend the interface with a default Supervisor robot, named ``Ros2Supervisor``.
+
+**Tutorial level:** Advanced
+
+**Time:** 10 minutes
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+
+Background
+----------
+
+In this tutorial, you will learn how to enable the ``Ros2Supervisor`` node which enhances the interface by creating additional services and topics to interact with the simulation.
+These instructions list in details the current implemented features and how to use them.
+
+Prerequisites
+-------------
+
+Before proceeding with this tutorial, make sure you have completed the following:
+
+- Understanding of ROS 2 nodes and topics covered in the beginner :doc:`../../../../Tutorials`.
+- Knowledge of Webots and ROS 2 and its interface package.
+- Familiarity with :doc:`./Setting-Up-Simulation-Webots-Basic`.
+
+The ``Ros2Supervisor``
+----------------------
+
+The ``Ros2Supervisor`` is made of two main parts:
+
+* A Webots Robot node added to the simulation world. Its Supervisor field is set to TRUE.
+* A ROS 2 node that connects to the Webots Robot as an extern controller (in a similar way to your own robot plugin).
+
+The ROS 2 node acts as a controller that calls Supervisor API functions to control or interact with the simulation world.
+User interactions with the ROS 2 node are mainly performed through services and topics.
+
+These nodes can be automatically created at the Webots launch using the ``ros2_supervisor`` parameter in the ``WebotsLauncher``.
+
+.. code-block:: python
+
+    webots = WebotsLauncher(
+        world=PathJoinSubstitution([package_dir, 'worlds', world]),
+        mode=mode,
+        ros2_supervisor=True
+    )
+
+The ``webots._supervisor`` object must also be included in the ``LaunchDescription`` returned by the launch file.
+
+.. code-block:: python
+
+    return LaunchDescription([
+        webots,
+        webots._supervisor,
+
+        # This action will kill all nodes once the Webots simulation has exited
+        launch.actions.RegisterEventHandler(
+            event_handler=launch.event_handlers.OnProcessExit(
+                target_action=webots,
+                on_exit=[
+                    launch.actions.EmitEvent(event=launch.events.Shutdown())
+                ],
+            )
+        )
+    ])
+
+More information about launch files for ``webots_ros2`` projects can be found in :doc:`./Setting-Up-Simulation-Webots-Basic`.
+
+Clock topic
+-----------
+
+The ``Ros2Supervisor`` node is responsible to get the time of the Webots simulation and publish it to the ``/clock`` topic.
+This means that it is mandatory to spawn the ``Ros2Supervisor`` if some other nodes have their ``use_sim_time`` parameter set to ``true``.
+More information about the ``/clock`` topic can be found in the `ROS wiki <http://wiki.ros.org/Clock>`_.
+
+Import a Webots node
+--------------------
+
+The ``Ros2Supervisor`` node also allows to spawn Webots nodes from strings through a service.
+
+The service is named ``/Ros2Supervisor/spawn_node_from_string`` and is of type ``webots_ros2_msgs/srv/SpawnNodeFromString``.
+The ``SpawnNodeFromString`` type expects a ``data`` string as input and returns a ``success`` boolean.
+
+From the given string, the Supervisor node is getting the name of the imported node and adding it to an intern list for potential later removal (see :ref:`Remove a Webots imported node`).
+
+The node is imported using the ``importMFNodeFromString(nodeString)`` `API function <https://cyberbotics.com/doc/reference/supervisor?tab-language=python#wb_supervisor_field_import_mf_node_from_string>`_.
+
+Here is an example to import a simple Robot named ``imported_robot``:
+
+.. code-block:: bash
+
+    ros2 service call /Ros2Supervisor/spawn_node_from_string webots_ros2_msgs/srv/SpawnNodeFromString "data: Robot { name \"imported_robot\" }"
+
+.. note::
+    If you try to import some PROTOs in the node string, their respective URLs must be declared in the .wbt world file as EXTERNPROTO or as IMPORTABLE EXTERNPROTO.
+
+.. _Remove a Webots imported node:
+
+Remove a Webots imported node
+-----------------------------
+
+Once a node has been imported with the ``/Ros2Supervisor/spawn_node_from_string`` service, it can also be removed.
+
+This can be achieved by sending the name of the node to the topic named ``/Ros2Supervisor/remove_node`` of type ``std_msgs/msg/String``.
+
+If the node is indeed in the imported list, it is removed with the ``remove()`` `API method <https://cyberbotics.com/doc/reference/supervisor?tab-language=python#wb_supervisor_node_remove>`_.
+
+Here is an example on how to remove the ``imported_robot`` Robot:
+
+.. code-block:: bash
+
+    ros2 topic pub --once /Ros2Supervisor/remove_node std_msgs/msg/String "{data: imported_robot}"
+
+Record animations
+-----------------
+
+The ``Ros2Supervisor`` node also creates two additional services to record HTML5 animations.
+
+The ``/Ros2Supervisor/animation_start_recording`` service is of type ``webots_ros2_msgs/srv/SetString`` and allows to start the animation.
+The ``SetString`` type expects a ``value`` string as input and returns a ``success`` boolean.
+The input ``value`` represents the absolute path to the directory where the animations files should be saved.
+
+Here is an example on how to start an animation:
+
+.. code-block:: bash
+
+    ros2 service call /Ros2Supervisor/animation_start_recording webots_ros2_msgs/srv/SetString "{value: "<ABSOLUTE_PATH>/index.html"}"
+
+
+The ``/Ros2Supervisor/animation_stop_recording`` service is of type ``webots_ros2_msgs/srv/GetBool`` and allows to stop the animation.
+
+.. code-block:: bash
+
+    ros2 service call /Ros2Supervisor/animation_stop_recording webots_ros2_msgs/srv/GetBool "{ask: True}"
+
+
+Summary
+-------
+
+In this tutorial, you learned how to enable the ``Ros2Supervisor`` and how to extend the interface with the Webots simulation.
+The node creates multiple services and topics to interact and modify the simulation.

--- a/source/Tutorials/Advanced/Simulators/Webots/Simulation-Webots.rst
+++ b/source/Tutorials/Advanced/Simulators/Webots/Simulation-Webots.rst
@@ -16,3 +16,4 @@ This set of tutorials will teach you how to configure the Webots simulator with 
    Setting-Up-Simulation-Webots-Basic
    Setting-Up-Simulation-Webots-Advanced
    Simulation-Reset-Handler
+   Simulation-Supervisor

--- a/source/Tutorials/Demos/Logging-and-logger-configuration.rst
+++ b/source/Tutorials/Demos/Logging-and-logger-configuration.rst
@@ -232,26 +232,86 @@ See `the source code <https://github.com/ros2/demos/blob/{REPOS_FILE_BRANCH}/log
 Logger level configuration: externally
 --------------------------------------
 
-In the future there will be a generalized approach to external configuration of loggers at runtime (similar to how `rqt_logger_level <https://wiki.ros.org/rqt_logger_level>`__ in ROS 1 allows logger configuration via remote procedural calls).
-**This concept is not yet officially supported in ROS 2.**
-In the meantime, this demo provides an **example** service that can be called externally to request configuration of logger levels for known names of loggers in the process.
+ROS 2 nodes have services available to configure the logging level externally at runtime.
+These services are disabled by default.
+The following code shows how to enable the logger service while creating the node.
 
-The demo previously started is already running this example service.
-To set the level of the demo's logger back to ``INFO``\ , call the service with:
+.. tabs::
+
+  .. group-tab:: Linux
+
+    .. code-block:: C++
+
+        // Create a node with logger service enabled
+        auto node = std::make_shared<rclcpp::Node>("NodeWithLoggerService", rclcpp::NodeOptions().enable_logger_service(true))
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+
+        # Create a node with logger service enabled
+        node = Node('NodeWithLoggerService', enable_logger_service=True)
+
+If you run one of the nodes as configured above, you will find 2 services when running ``ros2 service list``:
 
 .. code-block:: bash
 
-   ros2 service call /config_logger logging_demo/srv/ConfigLogger "{logger_name: 'logger_usage_demo', level: INFO}"
+    $ ros2 service list
+    ...
+    /NodeWithLoggerService/get_logger_levels
+    /NodeWithLoggerService/set_logger_levels
+    ...
 
-This service call will work on any logger that is running in the process provided that you know its name.
-This includes the loggers in the ROS 2 core, such as ``rcl`` (the common client library package).
-To enable debug logging for ``rcl``, call:
+* get_logger_levels
 
-.. code-block:: bash
+    Use this service to get logger levels for specified logger names.
 
-   ros2 service call /config_logger logging_demo/srv/ConfigLogger "{logger_name: 'rcl', level: DEBUG}"
+    Run ``ros2 service call`` to get logger levels for ``NodeWithLoggerService`` and ``rcl``.
 
-You should see debug output from ``rcl`` start to show.
+    .. code-block:: bash
+
+        $ ros2 service call /NodeWithLoggerService/get_logger_levels rcl_interfaces/srv/GetLoggerLevels '{names: ["NodeWithLoggerService", "rcl"]}'
+
+        requester: making request: rcl_interfaces.srv.GetLoggerLevels_Request(names=['NodeWithLoggerService', 'rcl'])
+
+        response:
+        rcl_interfaces.srv.GetLoggerLevels_Response(levels=[rcl_interfaces.msg.LoggerLevel(name='NodeWithLoggerService', level=0), rcl_interfaces.msg.LoggerLevel(name='rcl', level=0)])
+
+* set_logger_levels
+
+    Use this service to set logger levels for specified logger names.
+
+    Run ``ros2 service call`` to set logger levels for ``NodeWithLoggerService`` and ``rcl``.
+
+    .. code-block:: bash
+
+        $ ros2 service call /NodeWithLoggerService/set_logger_levels rcl_interfaces/srv/SetLoggerLevels '{levels: [{name: "NodeWithLoggerService", level: 20}, {name: "rcl", level: 10}]}'
+
+        requester: making request: rcl_interfaces.srv.SetLoggerLevels_Request(levels=[rcl_interfaces.msg.LoggerLevel(name='NodeWithLoggerService', level=20), rcl_interfaces.msg.LoggerLevel(name='rcl', level=10)])
+
+        response:
+        rcl_interfaces.srv.SetLoggerLevels_Response(results=[rcl_interfaces.msg.SetLoggerLevelsResult(successful=True, reason=''), rcl_interfaces.msg.SetLoggerLevelsResult(successful=True, reason='')])
+
+
+There is also demo code showing how to set or get the logger level via the logger service.
+
+  * rclcpp: `demo code <https://github.com/ros2/demos/tree/{REPOS_FILE_BRANCH}/demo_nodes_cpp/src/logging/use_logger_service.cpp>`__
+
+      .. code-block:: bash
+
+          $ ros2 run demo_nodes_cpp use_logger_service
+
+  * rclpy: `demo code <https://github.com/ros2/demos/tree/{REPOS_FILE_BRANCH}/demo_nodes_py/demo_nodes_py/logging/use_logger_service.py>`__
+
+      .. code-block:: bash
+
+          $ ros2 run demo_nodes_py use_logger_service
+
+.. warning::
+
+    Currently, there is a limitation that ``get_logger_levels`` and ``set_logger_levels`` services are not thread-safe.
+    This means that you need to ensure that only one thread is calling the services at a time.
+    Please see the details in https://github.com/ros2/rcutils/issues/397
 
 Using the logger config component
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.rst
@@ -486,6 +486,11 @@ The ``data_files`` field should now look like this:
 
 .. code-block:: Python
 
+   import os
+   from glob import glob
+   from setuptools import setup
+   ...
+
    data_files=[
          ...
          (os.path.join('share', package_name, 'launch'),


### PR DESCRIPTION
This PR is adding a new tutorial for the Webots simulator. A parameter in the `WebotsLauncher` node allows to add a Supervisor Robot to the simulation with a ROS 2 node as controller. This controller acts as an interface between the user and the simulation. The user can interact with the node using created services and topics. The tutorial lists all available features and how to use them.

This PR can be back-ported to Rolling, Humble and Iron.